### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,8 +33,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if item.user == current_user
-      item.destroy
+    if @item.user == current_user
+      @item.destroy
       redirect_to root_path
     else
       redirect_to root_path, alert: "You do not have permission to delete this item."

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,6 +32,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   def update
     if @item.update(item_params)
       redirect_to item_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:edit, :update, :show]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -33,9 +33,12 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
+    if item.user == current_user
+      item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path, alert: "You do not have permission to delete this item."
+    end  
   end
 
   def update

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
         <% if current_user == @item.user %>
           <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-          <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+          <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, method: :delete, class:"item-destroy" %>
         <% else %>
           <%= link_to "購入画面に進む", "#",class:"item-red-btn"%>
         <% end %>


### PR DESCRIPTION
#What
Furima-39499 プロジェクトのアイテムの削除機能を実装しました。
削除ボタンを追加し、対応するコントローラー アクションとビュー テンプレートを実装しました。
ユーザーはシステムからアイテムを削除できるようになりました。

#Why
削除機能により、ユーザーはプラットフォームから不要なアイテムを削除できるため、ユーザー エクスペリエンスが向上します。
これはプロジェクトの要件に合わせて、アイテムを管理するための完全な CRUD (作成、読み取り、更新、削除) 機能を提供します。
不要な項目を削除すると、データベースをクリーンで整理された状態に維持できます。
削除機能により、ユーザーは自分のアイテムを効果的に管理できる柔軟性が高まります。
実際の実装とプロジェクトに対するその重要性に基づいてコンテンツをカスタマイズしてください。